### PR TITLE
Reduce Hall of Fame threshold to 0.5 ETH for Base Summer

### DIFF
--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -204,7 +204,7 @@ export const SPONSOR_SCORING = {
 };
 
 export const SPONSOR_HOF_MAX_REWARDS = {
-  "base-summer": 1,
+  "base-summer": 0.5,
   base: 1,
 };
 


### PR DESCRIPTION
- Changed SPONSOR_HOF_MAX_REWARDS for base-summer from 1 to 0.5 ETH
- Regular Base campaigns remain at 1 ETH threshold